### PR TITLE
add TypeScript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,15 @@
+declare module 'asyncapi-validator' {
+  type Validator = {
+    validate: (
+      key: string,
+      payload: unknown,
+      channel: string,
+      operation: 'publish' | 'subscribe',
+    ) => void;
+  };
+
+  const fromSource: (
+    path: string | Record<string, unknown>,
+    options: { msgIdentifier: string; ignoreArray?: boolean },
+  ) => Promise<Validator>;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.1.0",
   "description": "message validator through asyncapi schema",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "jest",
     "lint": "./node_modules/.bin/eslint ./"


### PR DESCRIPTION
For https://github.com/WaleedAshraf/asyncapi-validator/issues/43

To test this I did `npm pack` to check that the `index.d.ts` is included, and used the module locally and checked that ts-jest is happy with it and VSCode reads it correctly.

Let me know if any changes are needed 🙂 