### PR TITLE
Example for validateByMessageId didn't actually use validateByMessageId

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ const AsyncApiValidator = require('asyncapi-validator')
 let va = await AsyncApiValidator.fromSource('./api.yaml')
 
 // validate messageId 'UserRemoved'
-va.validate('UserRemoved', {
+va.validateByMessageId('UserRemoved', {
   userId: '123456789',
   userEmail: 'alex@mail.com',
 })


### PR DESCRIPTION
I'm fairly sure this is a small mistake in the readme